### PR TITLE
Changed the lines() method to support Windows and OS 9 style line endings

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -291,7 +291,7 @@
 
     lines: function(str) {
       if (str == null) return [];
-      return String(str).split("\n");
+      return String(str).split(/\r\n?|\n/);
     },
 
     reverse: function(str){

--- a/test/strings.js
+++ b/test/strings.js
@@ -430,6 +430,9 @@ $(document).ready(function() {
 
   test('String: lines', function() {
     equal(_('Hello\nWorld').lines().length, 2);
+    equal(_('Hello\r\nWorld').lines().length, 2);
+    deepEqual(_('Hello\r\nWorld').lines(), ['Hello', 'World']);
+    equal(_('Hello\rWorld').lines().length, 2);
     equal(_('Hello World').lines().length, 1);
     equal(_(123).lines().length, 1);
     equal(_('').lines().length, 1);


### PR DESCRIPTION
This patch changes the behavior of the `lines()` method to correctly handle Windows and Mac OS 9 style line endings.

I do this by changing the search passed to the `split()` function from `"\n"` to `/\r\n?|\n/`.

This pull request is related to the request in issue #189.