### PR TITLE
Fixed capitalize not converting the rest of the string to lowercase

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -203,7 +203,7 @@
 
     capitalize : function(str){
       str = str == null ? '' : String(str);
-      return str.charAt(0).toUpperCase() + str.slice(1);
+      return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
     },
 
     chop: function(str, step){

--- a/test/strings.js
+++ b/test/strings.js
@@ -92,7 +92,7 @@ $(document).ready(function() {
   test('Strings: capitalize', function() {
     equal(_('fabio').capitalize(), 'Fabio', 'First letter is upper case');
     equal(_.capitalize('fabio'), 'Fabio', 'First letter is upper case');
-    equal(_.capitalize('FOO'), 'FOO', 'Other letters unchanged');
+    equal(_.capitalize('FABIO'), 'Fabio', 'Rest of the letters are lowercase');
     equal(_(123).capitalize(), '123', 'Non string');
     equal(_.capitalize(''), '', 'Capitalizing empty string returns empty string');
     equal(_.capitalize(null), '', 'Capitalizing null returns empty string');


### PR DESCRIPTION
Capitalize (according to Wikipedia and the Ruby String#capitalize) converts the
first letter to uppercase and the rest to lowercase. Implementation in this
library didn't convert the remainder to lowercase.

http://ruby-doc.org/core-2.0.0/String.html#method-i-capitalize
http://en.wikipedia.org/wiki/Capitalization