### PR TITLE
isBlank method now returns false when passing an object or array

### DIFF
--- a/lib/underscore.string.js
+++ b/lib/underscore.string.js
@@ -193,6 +193,7 @@
 
     isBlank: function(str){
       if (str == null) str = '';
+      if (typeof(str) == 'object') return false;
       return (/^\s*$/).test(str);
     },
 


### PR DESCRIPTION
I'm relatively new to GitHub contribution but here it goes:

I saw this issue https://github.com/epeli/underscore.string/issues/262 and decided to fix it, but I don't know if it was supposed to change or not. Anyway, here it's a possible solution.