### PR TITLE
Fix Bower warnings 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "underscore.string",
-  "version": "2.4.0",
+  "version": "3.0.0",
   "description": "String manipulation extensions for Underscore.js javascript library.",
   "homepage": "http://epeli.github.com/underscore.string/",
   "contributors": [

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
     "string"
   ],
   "main": "./dist/underscore.string.js",
+  "ignore": [],
   "repository": {
     "type": "git",
     "url": "https://github.com/epeli/underscore.string.git"


### PR DESCRIPTION
Looks like you forgot to bump the `bower.json` file. This patch fixes the "**mismatch**" warning and also adds the "ignore" entry to fix the "**invalid-meta**" property.

Just a little fix but I hope it makes your job as a maintainer a bit easier. Thanks for the great library.

```
bower info underscore.string
bower underscore.string#*       cached git://github.com/epeli/underscore.string.git#2.3.3
bower underscore.string#*     validate 2.3.3 against git://github.com/epeli/underscore.string.git#*
bower underscore.string#*          new version for git://github.com/epeli/underscore.string.git#*
bower underscore.string#*      resolve git://github.com/epeli/underscore.string.git#*
bower underscore.string#*     download https://github.com/epeli/underscore.string/archive/3.0.0.tar.gz
bower underscore.string#*      extract archive.tar.gz
bower underscore.string#*     mismatch Version declared in the json (2.4.0) is different than the resolved one (3.0.0)
bower underscore.string#* invalid-meta underscore.string is missing "ignore" entry in bower.json
bower underscore.string#*     resolved git://github.com/epeli/underscore.string.git#3.0.0
```