### PR TITLE
provide `dist/underscore.string.min.js` in the npm package (again)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
 test
-dist


### PR DESCRIPTION
Browser window's context and Node.js context [are different](https://github.com/nwjs/nw.js/wiki/Differences-of-JavaScript-contexts) in [nw.js](https://github.com/nwjs/nw.js) and it takes some time to switch between them.

Therefore, when `underscore.string` is used inside an [nwjs](https://github.com/nwjs/nw.js)-based application, it sometimes makes sense to do **both** of the following:

* declare `underscore.string` as a dependency in `package.json` ([example](https://github.com/Mithgol/phido/blob/5af373bbd81d0eae5b6c523f9060b5e5ba4d3297/package.json#L20)) and let it be installed with `npm install`

* use `underscore.string` in a browser's window context with `<script>` ([example](https://github.com/Mithgol/phido/blob/5af373bbd81d0eae5b6c523f9060b5e5ba4d3297/index.html#L15)) instead of (or in addition to) Node.js context with `require()`.

However, the npm package of `underscore.string` does not currently contain the `dist/underscore.string.min.js` file that could be installed and referenced by the `script` element.

That's why this pull request partially reverts c3088d48dd07bbdb9e782840cfcb94c9ece5ef0c (and #193): the minified file `dist/underscore.string.min.js` is re-added to the npm package. (The larger file `dist/underscore.string.js` continues to be removed from the package.)