### PR TITLE
 Add flag to capitalize to lowercase remaining characters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -138,13 +138,17 @@ levenshtein("kitten", "kittah");
 // => 2
 ```
 
-#### capitalize(string) => string
+#### capitalize(string, [lowercaseRest=false]) => string
 
-Converts first letter of the string to uppercase.
+Converts first letter of the string to uppercase. If `true` is passed as second argument the rest
+of the string will be converted to lower case.
 
 ```javascript
 capitalize("foo Bar");
 // => "Foo Bar"
+
+capitalize("FOO Bar", true);
+// => "Foo bar"
 ```
 
 #### decapitalize(string) => string

--- a/capitalize.js
+++ b/capitalize.js
@@ -1,6 +1,8 @@
 var makeString = require('./helper/makeString');
 
-module.exports = function capitalize(str) {
+module.exports = function capitalize(str, lowercaseRest) {
   str = makeString(str);
-  return str.charAt(0).toUpperCase() + str.slice(1);
+  var remainingChars = !lowercaseRest ? str.slice(1) : str.slice(1).toLowerCase();
+
+  return str.charAt(0).toUpperCase() + remainingChars;
 };

--- a/test/strings.js
+++ b/test/strings.js
@@ -129,6 +129,10 @@ $(document).ready(function() {
     equal(_('fabio').capitalize(), 'Fabio', 'First letter is upper case');
     equal(_.capitalize('fabio'), 'Fabio', 'First letter is upper case');
     equal(_.capitalize('FOO'), 'FOO', 'Other letters unchanged');
+    equal(_.capitalize('FOO', false), 'FOO', 'Other letters unchanged');
+    equal(_.capitalize('foO', false), 'FoO', 'Other letters unchanged');
+    equal(_.capitalize('FOO', true), 'Foo', 'Other letters are lowercased');
+    equal(_.capitalize('foO', true), 'Foo', 'Other letters are lowercased');
     equal(_(123).capitalize(), '123', 'Non string');
     equal(_.capitalize(''), '', 'Capitalizing empty string returns empty string');
     equal(_.capitalize(null), '', 'Capitalizing null returns empty string');


### PR DESCRIPTION
This adds a new flag to capitalize that when set to `true` will convert all characters after the first one to lowercase. Example:

    capitalize("FOO Bar", true);
    // => "Foo bar"