### PR TITLE
issue301 Closes #301 Adds an htmlEntity helper for entities that should ...

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -211,6 +211,7 @@ count("Hello world", "l");
 #### escapeHTML(string) => string
 
 Converts HTML special characters to their entity equivalents.
+This function supports cent, yen, euro, pound, lt, gt, copy, reg, quote, amp, apos.
 
 ```javascript
 escapeHTML("<div>Blah blah blah</div>");
@@ -220,9 +221,10 @@ escapeHTML("<div>Blah blah blah</div>");
 #### unescapeHTML(string) => string
 
 Converts entity characters to HTML equivalents.
+This function supports cent, yen, euro, pound, lt, gt, copy, reg, quote, amp, apos, nbsp.
 
 ```javascript
-unescapeHTML("&lt;div&gt;Blah blah blah&lt;/div&gt;");
+unescapeHTML("&lt;div&gt;Blah&nbsp;blah blah&lt;/div&gt;");
 // => "<div>Blah blah blah</div>"
 ```
 

--- a/escapeHTML.js
+++ b/escapeHTML.js
@@ -2,11 +2,17 @@ var makeString = require('./helper/makeString');
 var escapeChars = require('./helper/escapeChars');
 var reversedEscapeChars = {};
 
-for(var key in escapeChars) reversedEscapeChars[escapeChars[key]] = key;
-reversedEscapeChars["'"] = '#39';
+var regexString = "[";
+for(var key in escapeChars) {
+  regexString += key;
+}
+regexString += "]";
+
+var regex = new RegExp( regexString, 'g');
 
 module.exports = function escapeHTML(str) {
-  return makeString(str).replace(/[&<>"']/g, function(m) {
-    return '&' + reversedEscapeChars[m] + ';';
+
+  return makeString(str).replace(regex, function(m) {
+    return '&' + escapeChars[m] + ';';
   });
 };

--- a/helper/escapeChars.js
+++ b/helper/escapeChars.js
@@ -1,9 +1,19 @@
+/* We're explicitly defining the list of entities we want to escape.
+nbsp is an HTML entity, but we don't want to escape all space characters in a string, hence its omission in this map.
+
+*/
 var escapeChars = {
-  lt: '<',
-  gt: '>',
-  quot: '"',
-  amp: '&',
-  apos: "'"
+  '¢' : 'cent',
+  '£' : 'pound',
+  '¥' : 'yen',
+  '€': 'euro',
+  '©' :'copy',
+  '®' : 'reg',
+  '<' : 'lt',
+  '>' : 'gt',
+  '"' : 'quot',
+  '&' : 'amp',
+  "'": '#39'
 };
 
 module.exports = escapeChars;

--- a/helper/htmlEntities.js
+++ b/helper/htmlEntities.js
@@ -1,0 +1,19 @@
+/*
+We're explicitly defining the list of entities that might see in escape HTML strings
+*/
+var htmlEntities = {
+  nbsp: ' ',
+  cent: '¢',
+  pound: '£',
+  yen: '¥',
+  euro: '€',
+  copy: '©',
+  reg: '®',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  amp: '&',
+  apos: "'"
+};
+
+module.exports = htmlEntities;

--- a/tests/escapeHTML.js
+++ b/tests/escapeHTML.js
@@ -5,9 +5,11 @@ var escapeHTML = require('../escapeHTML');
 test('#escapeHTML', function(){
   equal(escapeHTML('<div>Blah & "blah" & \'blah\'</div>'), '&lt;div&gt;Blah &amp; &quot;blah&quot; &amp; &#39;blah&#39;&lt;/div&gt;');
   equal(escapeHTML('&lt;'), '&amp;lt;');
+  equal(escapeHTML(' '), ' ');
+  equal(escapeHTML('¢'), '&cent;')
+  equal(escapeHTML('¢ £ ¥ € © ®'), '&cent; &pound; &yen; &euro; &copy; &reg;')
   equal(escapeHTML(5), '5');
   equal(escapeHTML(''), '');
   equal(escapeHTML(null), '');
   equal(escapeHTML(undefined), '');
 });
-

--- a/tests/unescapeHTML.js
+++ b/tests/unescapeHTML.js
@@ -16,9 +16,16 @@ test('#unescapeHTML', function(){
   equal(unescapeHTML('&#39_;'), '&#39_;');
   equal(unescapeHTML('&amp;#38;'), '&#38;');
   equal(unescapeHTML('&#38;amp;'), '&amp;');
+  equal(unescapeHTML('&#39;'), "'");
   equal(unescapeHTML(''), '');
+  equal(unescapeHTML('&nbsp;'), ' ');
+  equal(unescapeHTML('what is the &yen; to &pound; to &euro; conversion process?'), 'what is the ¥ to £ to € conversion process?');
+  equal(unescapeHTML('&reg; trademark'), '® trademark');
+  equal(unescapeHTML('&copy; 1992. License available for 50 &cent;'), '© 1992. License available for 50 ¢');
+  equal(unescapeHTML('&nbsp;'), ' ');
+  equal(unescapeHTML('&nbsp;'), ' ');
+
   equal(unescapeHTML(null), '');
   equal(unescapeHTML(undefined), '');
   equal(unescapeHTML(5), '5');
 });
-

--- a/unescapeHTML.js
+++ b/unescapeHTML.js
@@ -1,12 +1,12 @@
 var makeString = require('./helper/makeString');
-var escapeChars = require('./helper/escapeChars');
+var htmlEntities = require('./helper/htmlEntities');
 
 module.exports = function unescapeHTML(str) {
   return makeString(str).replace(/\&([^;]+);/g, function(entity, entityCode) {
     var match;
 
-    if (entityCode in escapeChars) {
-      return escapeChars[entityCode];
+    if (entityCode in htmlEntities) {
+      return htmlEntities[entityCode];
     } else if (match = entityCode.match(/^#x([\da-fA-F]+)$/)) {
       return String.fromCharCode(parseInt(match[1], 16));
     } else if (match = entityCode.match(/^#(\d+)$/)) {


### PR DESCRIPTION
...be unescaped but do not need to be scaped.  We can use the escapeChars helper to handle the smaller set of html escape chars

Please note that I did not commit the dist/ files.  My assumption is they get built at release time.  I also added a set of the html entities, but it's not exhaustive.  I could remove the extras and just add nbsp to the escape codes array.