### PR TITLE
Fix minor typo in contributing docs

### DIFF
--- a/CONTRIBUTING.markdown
+++ b/CONTRIBUTING.markdown
@@ -15,8 +15,8 @@ it for verification.
 It's recommended to open an issue before sending a pull request to avoid
 unnecessary work. There are quite few areas we consider to be out of scope for
 this library. Idea is to add few generic string helpers for Javascript. For
-example anything related to internalization or is too language specific is out
-of scope.
+example anything related to internationalization or is too language specific
+is out of scope.
 
 ## Release checklist
 


### PR DESCRIPTION
`internalization` should be `interna*tiona*lization` :-)

- [internalization](https://en.wikipedia.org/wiki/Internalization)
- [internationalization](https://en.wikipedia.org/wiki/Internationalization_and_localization)
