### PR TITLE
Update truncate function documentation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -442,7 +442,7 @@ Left trim. Similar to trim, but only for left side.
 
 Right trim. Similar to trim, but only for right side.
 
-#### truncate(string, length, truncateString) => string
+#### truncate(string, length, [truncateString = '...']) => string
 
 ```javascript
 truncate("Hello world", 5);


### PR DESCRIPTION
Since The third argument of truncate function is optional and the default value of it is '...', I changed the documentation of this function so it would be more clarified and easy to use.