### PR TITLE
do not `escapeHTML()` characters that are not HTML special characters

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -213,7 +213,7 @@ count("Hello world", "l");
 #### escapeHTML(string) => string
 
 Converts HTML special characters to their entity equivalents.
-This function supports cent, yen, euro, pound, lt, gt, copy, reg, quote, amp, apos.
+This function supports lt, gt, quote, amp, apos.
 
 ```javascript
 escapeHTML("<div>Blah blah blah</div>");

--- a/helper/escapeChars.js
+++ b/helper/escapeChars.js
@@ -3,12 +3,6 @@ nbsp is an HTML entity, but we don't want to escape all space characters in a st
 
 */
 var escapeChars = {
-  '¢' : 'cent',
-  '£' : 'pound',
-  '¥' : 'yen',
-  '€': 'euro',
-  '©' :'copy',
-  '®' : 'reg',
   '<' : 'lt',
   '>' : 'gt',
   '"' : 'quot',

--- a/tests/escapeHTML.js
+++ b/tests/escapeHTML.js
@@ -6,8 +6,6 @@ test('#escapeHTML', function(){
   equal(escapeHTML('<div>Blah & "blah" & \'blah\'</div>'), '&lt;div&gt;Blah &amp; &quot;blah&quot; &amp; &#39;blah&#39;&lt;/div&gt;');
   equal(escapeHTML('&lt;'), '&amp;lt;');
   equal(escapeHTML(' '), ' ');
-  equal(escapeHTML('¢'), '&cent;')
-  equal(escapeHTML('¢ £ ¥ € © ®'), '&cent; &pound; &yen; &euro; &copy; &reg;')
   equal(escapeHTML(5), '5');
   equal(escapeHTML(''), '');
   equal(escapeHTML(null), '');


### PR DESCRIPTION
The method `escapeHTML()` is said to escape HTML special characters.

However, it also escapes `¢`, `£`, `¥`, `€`, `©`, `®`. These characters do not have any special meaning in HTML and thus their conversion (in my opinion) does not bring any real benefits but only unnecessarily lengthens a string and wastes processing power.

This pull request prevents their further escaping by partially reverting #417. The issue #301 remains fixed because the `unescapeHTML()` method is not altered.