### PR TITLE
lines: add carriage-return only case to regex

### DIFF
--- a/lines.js
+++ b/lines.js
@@ -1,4 +1,4 @@
 module.exports = function lines(str) {
   if (str == null) return [];
-  return String(str).split(/\r?\n/);
+  return String(str).split(/\r|\r?\n/);
 };

--- a/lines.js
+++ b/lines.js
@@ -1,4 +1,4 @@
 module.exports = function lines(str) {
   if (str == null) return [];
-  return String(str).split(/\r|\r?\n/);
+  return String(str).split(/\r\n?|\n/);
 };

--- a/tests/lines.js
+++ b/tests/lines.js
@@ -5,6 +5,7 @@ var lines = require('../lines');
 
 test('#lines', function() {
   equal(lines('Hello\nWorld').length, 2);
+  equal(lines('Hello\rWorld').length, 2);
   equal(lines('Hello World').length, 1);
   equal(lines(123).length, 1);
   deepEqual(lines(''), ['']);

--- a/tests/lines.js
+++ b/tests/lines.js
@@ -10,7 +10,7 @@ test('#lines', function() {
   deepEqual(lines(''), ['']);
   deepEqual(lines(null), []);
   deepEqual(lines(undefined), []);
-  deepEqual(lines('Hello\rWorld'), ['Hello\rWorld']);
+  deepEqual(lines('Hello\rWorld'), ['Hello', 'World']);
   deepEqual(lines('Hello\r\nWorld'), ['Hello', 'World']);
 });
 

--- a/tests/lines.js
+++ b/tests/lines.js
@@ -7,6 +7,9 @@ test('#lines', function() {
   equal(lines('Hello\nWorld').length, 2);
   equal(lines('Hello\rWorld').length, 2);
   equal(lines('Hello World').length, 1);
+  equal(lines('\r\n\n\r').length, 4);
+  equal(lines('Hello\r\r\nWorld').length, 3);
+  equal(lines('Hello\r\rWorld').length, 3);
   equal(lines(123).length, 1);
   deepEqual(lines(''), ['']);
   deepEqual(lines(null), []);


### PR DESCRIPTION
Old Mac OS versions and Excel for Mac exported CVS uses the *CR* only at end of lines:

New line representations: https://en.wikipedia.org/wiki/Newline#Representations
Excel issue: http://nicercode.github.io/blog/2013-04-30-excel-and-line-endings/