### PR TITLE
Extract cleanDiacritics from slugify

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -176,6 +176,21 @@ clean(" foo    bar   ");
 // => "foo bar"
 ```
 
+#### cleanDiacritics(string) => string
+
+Replace [diacritic][d] characters with closest ASCII equivalents. Check the
+[source][s] for supported characters. [Pull requests][p] welcome for missing
+characters!
+
+[d]: https://en.wikipedia.org/wiki/Diacritic
+[s]: https://github.com/epeli/underscore.string/blob/master/cleanDiacritics.js
+[p]: https://github.com/epeli/underscore.string/blob/master/CONTRIBUTING.markdown
+
+```javascript
+cleanDiacritics("ääkkönen");
+// => "aakkonen"
+```
+
 #### chars(string) => array
 
 ```javascript

--- a/cleanDiacritics.js
+++ b/cleanDiacritics.js
@@ -1,0 +1,15 @@
+
+var makeString = require('./helper/makeString');
+
+var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz";
+
+from += from.toUpperCase();
+to += to.toUpperCase();
+
+module.exports = function cleanDiacritics(str) {
+    return makeString(str).replace(/.{1}/g, function(c){
+      var index = from.indexOf(c);
+      return index === -1 ? c : to.charAt(index);
+  });
+};

--- a/slugify.js
+++ b/slugify.js
@@ -2,16 +2,8 @@ var makeString = require('./helper/makeString');
 var defaultToWhiteSpace = require('./helper/defaultToWhiteSpace');
 var trim = require('./trim');
 var dasherize = require('./dasherize');
+var cleanDiacritics = require("./cleanDiacritics");
 
 module.exports = function slugify(str) {
-  var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž",
-      to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz",
-      regex = new RegExp(defaultToWhiteSpace(from), 'g');
-
-  str = makeString(str).toLowerCase().replace(regex, function(c){
-    var index = from.indexOf(c);
-    return to.charAt(index) || '-';
-  });
-
-  return trim(dasherize(str.replace(/[^\w\s-]/g, '-')), '-');
+  return trim(dasherize(cleanDiacritics(str).replace(/[^\w\s-]/g, '-')), '-');
 };

--- a/tests/cleanDiacritics.js
+++ b/tests/cleanDiacritics.js
@@ -1,0 +1,21 @@
+
+var equal = require('assert').equal;
+var cleanDiacritics = require('../cleanDiacritics');
+
+var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz";
+
+test('#cleanDiacritics', function() {
+
+  equal(cleanDiacritics(from), to);
+  equal(cleanDiacritics(from.toUpperCase()), to.toUpperCase());
+
+
+  equal(cleanDiacritics('ä'), 'a');
+  equal(cleanDiacritics('Ä Ø'), 'A O');
+  equal(cleanDiacritics('1 foo ääkkönen'), '1 foo aakkonen');
+  equal(cleanDiacritics('Äöö ÖÖ'), 'Aoo OO');
+  equal(cleanDiacritics(' ä '), ' a ');
+  equal(cleanDiacritics('- " , £ $ ä'), '- " , £ $ a');
+});
+


### PR DESCRIPTION
Quite a few times I have needed a custom version of the slugify function and this is the main feature I do not want to reimplement.

For example today I needed a slugify function which preserves dots and removes all other non a-z chars.