### PR TITLE
Fix regression in slugify. E.g. slugify('HALO') = '-h-a-l-o'

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -5,5 +5,5 @@ var dasherize = require('./dasherize');
 var cleanDiacritics = require("./cleanDiacritics");
 
 module.exports = function slugify(str) {
-  return trim(dasherize(cleanDiacritics(str).replace(/[^\w\s-]/g, '-')), '-');
+  return trim(dasherize(cleanDiacritics(str).replace(/[^\w\s-]/g, '-').toLowerCase()), '-');
 };

--- a/tests/slugify.js
+++ b/tests/slugify.js
@@ -8,6 +8,7 @@ test('#slugify', function() {
   equal(slugify('I know latin characters: á í ó ú ç ã õ ñ ü ă ș ț'), 'i-know-latin-characters-a-i-o-u-c-a-o-n-u-a-s-t');
   equal(slugify('I am a word too, even though I am but a single letter: i!'), 'i-am-a-word-too-even-though-i-am-but-a-single-letter-i');
   equal(slugify('Some asian 天地人 characters'), 'some-asian-characters');
+  equal(slugify('SOME Capital Letters'), 'some-capital-letters');
   equal(slugify(''), '');
   equal(slugify(null), '');
   equal(slugify(undefined), '');


### PR DESCRIPTION
This regression was introduced with https://github.com/epeli/underscore.string/commit/4124d03e3ca7f0194cacce1d64e7c68125edf331.

So `underscore.string v3.2.0` and `underscore.string v3.2.1` are currently affected.