### PR TITLE
update sprintf to 1.0.3 and add tests

### DIFF
--- a/sprintf.js
+++ b/sprintf.js
@@ -1,124 +1,186 @@
-// sprintf() for JavaScript 0.7-beta1
+// sprintf() for JavaScript 1.0.3
 // http://www.diveintojavascript.com/projects/javascript-sprintf
 //
 // Copyright (c) Alexandru Marasteanu <alexaholic [at) gmail (dot] com>
 // All rights reserved.
-var strRepeat = require('./helper/strRepeat');
-var toString = Object.prototype.toString;
-var sprintf = (function() {
-  function get_type(variable) {
-    return toString.call(variable).slice(8, -1).toLowerCase();
-  }
+var re = {
+    not_string: /[^s]/,
+    number: /[diefg]/,
+    json: /[j]/,
+    not_json: /[^j]/,
+    text: /^[^\x25]+/,
+    modulo: /^\x25{2}/,
+    placeholder: /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-gijosuxX])/,
+    key: /^([a-z_][a-z_\d]*)/i,
+    key_access: /^\.([a-z_][a-z_\d]*)/i,
+    index_access: /^\[(\d+)\]/,
+    sign: /^[\+\-]/
+}
 
-  var str_repeat = strRepeat;
-
-  var str_format = function() {
-    if (!str_format.cache.hasOwnProperty(arguments[0])) {
-      str_format.cache[arguments[0]] = str_format.parse(arguments[0]);
+function sprintf() {
+    var key = arguments[0], cache = sprintf.cache
+    if (!(cache[key] && cache.hasOwnProperty(key))) {
+        cache[key] = sprintf.parse(key)
     }
-    return str_format.format.call(null, str_format.cache[arguments[0]], arguments);
-  };
+    return sprintf.format.call(null, cache[key], arguments)
+}
 
-  str_format.format = function(parse_tree, argv) {
-    var cursor = 1, tree_length = parse_tree.length, node_type = '', arg, output = [], i, k, match, pad, pad_character, pad_length;
+sprintf.format = function(parse_tree, argv) {
+    var cursor = 1, tree_length = parse_tree.length, node_type = "", arg, output = [], i, k, match, pad, pad_character, pad_length, is_positive = true, sign = ""
     for (i = 0; i < tree_length; i++) {
-      node_type = get_type(parse_tree[i]);
-      if (node_type === 'string') {
-        output.push(parse_tree[i]);
-      }
-      else if (node_type === 'array') {
-        match = parse_tree[i]; // convenience purposes only
-        if (match[2]) { // keyword argument
-          arg = argv[cursor];
-          for (k = 0; k < match[2].length; k++) {
-            if (!arg.hasOwnProperty(match[2][k])) {
-              throw new Error(sprintf('[_.sprintf] property "%s" does not exist', match[2][k]));
+        node_type = get_type(parse_tree[i])
+        if (node_type === "string") {
+            output[output.length] = parse_tree[i]
+        }
+        else if (node_type === "array") {
+            match = parse_tree[i] // convenience purposes only
+            if (match[2]) { // keyword argument
+                arg = argv[cursor]
+                for (k = 0; k < match[2].length; k++) {
+                    if (!arg.hasOwnProperty(match[2][k])) {
+                        throw new Error(sprintf("[sprintf] property '%s' does not exist", match[2][k]))
+                    }
+                    arg = arg[match[2][k]]
+                }
             }
-            arg = arg[match[2][k]];
-          }
-        } else if (match[1]) { // positional argument (explicit)
-          arg = argv[match[1]];
-        }
-        else { // positional argument (implicit)
-          arg = argv[cursor++];
-        }
+            else if (match[1]) { // positional argument (explicit)
+                arg = argv[match[1]]
+            }
+            else { // positional argument (implicit)
+                arg = argv[cursor++]
+            }
 
-        if (/[^s]/.test(match[8]) && (get_type(arg) != 'number')) {
-          throw new Error(sprintf('[_.sprintf] expecting number but found %s', get_type(arg)));
+            if (get_type(arg) == "function") {
+                arg = arg()
+            }
+
+            if (re.not_string.test(match[8]) && re.not_json.test(match[8]) && (get_type(arg) != "number" && isNaN(arg))) {
+                throw new TypeError(sprintf("[sprintf] expecting number but found %s", get_type(arg)))
+            }
+
+            if (re.number.test(match[8])) {
+                is_positive = arg >= 0
+            }
+
+            switch (match[8]) {
+                case "b":
+                    arg = arg.toString(2)
+                break
+                case "c":
+                    arg = String.fromCharCode(arg)
+                break
+                case "d":
+                case "i":
+                    arg = parseInt(arg, 10)
+                break
+                case "j":
+                    arg = JSON.stringify(arg, null, match[6] ? parseInt(match[6]) : 0)
+                break
+                case "e":
+                    arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential()
+                break
+                case "f":
+                    arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg)
+                break
+                case "g":
+                    arg = match[7] ? parseFloat(arg).toPrecision(match[7]) : parseFloat(arg)
+                break
+                case "o":
+                    arg = arg.toString(8)
+                break
+                case "s":
+                    arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg)
+                break
+                case "u":
+                    arg = arg >>> 0
+                break
+                case "x":
+                    arg = arg.toString(16)
+                break
+                case "X":
+                    arg = arg.toString(16).toUpperCase()
+                break
+            }
+            if (re.json.test(match[8])) {
+                output[output.length] = arg
+            }
+            else {
+                if (re.number.test(match[8]) && (!is_positive || match[3])) {
+                    sign = is_positive ? "+" : "-"
+                    arg = arg.toString().replace(re.sign, "")
+                }
+                else {
+                    sign = ""
+                }
+                pad_character = match[4] ? match[4] === "0" ? "0" : match[4].charAt(1) : " "
+                pad_length = match[6] - (sign + arg).length
+                pad = match[6] ? (pad_length > 0 ? str_repeat(pad_character, pad_length) : "") : ""
+                output[output.length] = match[5] ? sign + arg + pad : (pad_character === "0" ? sign + pad + arg : pad + sign + arg)
+            }
         }
-        switch (match[8]) {
-          case 'b': arg = arg.toString(2); break;
-          case 'c': arg = String.fromCharCode(arg); break;
-          case 'd': arg = parseInt(arg, 10); break;
-          case 'e': arg = match[7] ? arg.toExponential(match[7]) : arg.toExponential(); break;
-          case 'f': arg = match[7] ? parseFloat(arg).toFixed(match[7]) : parseFloat(arg); break;
-          case 'o': arg = arg.toString(8); break;
-          case 's': arg = ((arg = String(arg)) && match[7] ? arg.substring(0, match[7]) : arg); break;
-          case 'u': arg = Math.abs(arg); break;
-          case 'x': arg = arg.toString(16); break;
-          case 'X': arg = arg.toString(16).toUpperCase(); break;
-        }
-        arg = (/[def]/.test(match[8]) && match[3] && arg >= 0 ? '+'+ arg : arg);
-        pad_character = match[4] ? match[4] == '0' ? '0' : match[4].charAt(1) : ' ';
-        pad_length = match[6] - String(arg).length;
-        pad = match[6] ? str_repeat(pad_character, pad_length) : '';
-        output.push(match[5] ? arg + pad : pad + arg);
-      }
     }
-    return output.join('');
-  };
+    return output.join("")
+}
 
-  str_format.cache = {};
+sprintf.cache = {}
 
-  str_format.parse = function(fmt) {
-    var _fmt = fmt, match = [], parse_tree = [], arg_names = 0;
+sprintf.parse = function(fmt) {
+    var _fmt = fmt, match = [], parse_tree = [], arg_names = 0
     while (_fmt) {
-      if ((match = /^[^\x25]+/.exec(_fmt)) !== null) {
-        parse_tree.push(match[0]);
-      }
-      else if ((match = /^\x25{2}/.exec(_fmt)) !== null) {
-        parse_tree.push('%');
-      }
-      else if ((match = /^\x25(?:([1-9]\d*)\$|\(([^\)]+)\))?(\+)?(0|'[^$])?(-)?(\d+)?(?:\.(\d+))?([b-fosuxX])/.exec(_fmt)) !== null) {
-        if (match[2]) {
-          arg_names |= 1;
-          var field_list = [], replacement_field = match[2], field_match = [];
-          if ((field_match = /^([a-z_][a-z_\d]*)/i.exec(replacement_field)) !== null) {
-            field_list.push(field_match[1]);
-            while ((replacement_field = replacement_field.substring(field_match[0].length)) !== '') {
-              if ((field_match = /^\.([a-z_][a-z_\d]*)/i.exec(replacement_field)) !== null) {
-                field_list.push(field_match[1]);
-              }
-              else if ((field_match = /^\[(\d+)\]/.exec(replacement_field)) !== null) {
-                field_list.push(field_match[1]);
-              }
-              else {
-                throw new Error('[_.sprintf] huh?');
-              }
+        if ((match = re.text.exec(_fmt)) !== null) {
+            parse_tree[parse_tree.length] = match[0]
+        }
+        else if ((match = re.modulo.exec(_fmt)) !== null) {
+            parse_tree[parse_tree.length] = "%"
+        }
+        else if ((match = re.placeholder.exec(_fmt)) !== null) {
+            if (match[2]) {
+                arg_names |= 1
+                var field_list = [], replacement_field = match[2], field_match = []
+                if ((field_match = re.key.exec(replacement_field)) !== null) {
+                    field_list[field_list.length] = field_match[1]
+                    while ((replacement_field = replacement_field.substring(field_match[0].length)) !== "") {
+                        if ((field_match = re.key_access.exec(replacement_field)) !== null) {
+                            field_list[field_list.length] = field_match[1]
+                        }
+                        else if ((field_match = re.index_access.exec(replacement_field)) !== null) {
+                            field_list[field_list.length] = field_match[1]
+                        }
+                        else {
+                            throw new SyntaxError("[sprintf] failed to parse named argument key")
+                        }
+                    }
+                }
+                else {
+                    throw new SyntaxError("[sprintf] failed to parse named argument key")
+                }
+                match[2] = field_list
             }
-          }
-          else {
-            throw new Error('[_.sprintf] huh?');
-          }
-          match[2] = field_list;
+            else {
+                arg_names |= 2
+            }
+            if (arg_names === 3) {
+                throw new Error("[sprintf] mixing positional and named placeholders is not (yet) supported")
+            }
+            parse_tree[parse_tree.length] = match
         }
         else {
-          arg_names |= 2;
+            throw new SyntaxError("[sprintf] unexpected placeholder")
         }
-        if (arg_names === 3) {
-          throw new Error('[_.sprintf] mixing positional and named placeholders is not (yet) supported');
-        }
-        parse_tree.push(match);
-      }
-      else {
-        throw new Error('[_.sprintf] huh?');
-      }
-      _fmt = _fmt.substring(match[0].length);
+        _fmt = _fmt.substring(match[0].length)
     }
-    return parse_tree;
-  };
+    return parse_tree
+}
 
-  return str_format;
-})();
+/**
+ * helpers
+ */
+function get_type(variable) {
+    return Object.prototype.toString.call(variable).slice(8, -1).toLowerCase()
+}
+
+function str_repeat(input, multiplier) {
+    return Array(multiplier + 1).join(input)
+}
 
 module.exports = sprintf;

--- a/tests/sprintf.js
+++ b/tests/sprintf.js
@@ -1,15 +1,82 @@
-var equal = require('assert').equal;
+// sprintf() for JavaScript 1.0.3
+// http://www.diveintojavascript.com/projects/javascript-sprintf
+//
+// Copyright (c) Alexandru Marasteanu <alexaholic [at) gmail (dot] com>
+// All rights reserved.
+var assert = require('assert');
 var sprintf = require('../sprintf');
 
-
 test('#sprintf', function() {
-  // Should be very tested function already.  Thanks to
-  // http://www.diveintojavascript.com/projects/sprintf-for-javascript
-  equal(sprintf('Hello %s', 'me'), 'Hello me', 'basic');
-  equal(sprintf('Hello %s', 'me'), 'Hello me', 'object');
-  equal(sprintf('%.1f', 1.22222), '1.2', 'round');
-  equal(sprintf('%.1f', 1.17), '1.2', 'round 2');
-  equal(sprintf('%(id)d - %(name)s', {id: 824, name: 'Hello World'}), '824 - Hello World', 'Named replacements work');
-  equal(sprintf('%(args[0].id)d - %(args[1].name)s', {args: [{id: 824}, {name: 'Hello World'}]}), '824 - Hello World', 'Named replacements with arrays work');
+  var pi = 3.141592653589793
+
+  // should return formated strings for simple placeholders
+  assert.equal("%", sprintf("%%"))
+  assert.equal("10", sprintf("%b", 2))
+  assert.equal("A", sprintf("%c", 65))
+  assert.equal("2", sprintf("%d", 2))
+  assert.equal("2", sprintf("%i", 2))
+  assert.equal("2", sprintf("%d", "2"))
+  assert.equal("2", sprintf("%i", "2"))
+  assert.equal('{"foo":"bar"}', sprintf("%j", {foo: "bar"}))
+  assert.equal('["foo","bar"]', sprintf("%j", ["foo", "bar"]))
+  assert.equal("2e+0", sprintf("%e", 2))
+  assert.equal("2", sprintf("%u", 2))
+  assert.equal("4294967294", sprintf("%u", -2))
+  assert.equal("2.2", sprintf("%f", 2.2))
+  assert.equal("3.141592653589793", sprintf("%g", pi))
+  assert.equal("10", sprintf("%o", 8))
+  assert.equal("%s", sprintf("%s", "%s"))
+  assert.equal("ff", sprintf("%x", 255))
+  assert.equal("FF", sprintf("%X", 255))
+  assert.equal("Polly wants a cracker", sprintf("%2$s %3$s a %1$s", "cracker", "Polly", "wants"))
+  assert.equal("Hello world!", sprintf("Hello %(who)s!", {"who": "world"}))
+
+  // should return formated strings for complex placeholders
+  // sign
+  assert.equal("2", sprintf("%d", 2))
+  assert.equal("-2", sprintf("%d", -2))
+  assert.equal("+2", sprintf("%+d", 2))
+  assert.equal("-2", sprintf("%+d", -2))
+  assert.equal("2", sprintf("%i", 2))
+  assert.equal("-2", sprintf("%i", -2))
+  assert.equal("+2", sprintf("%+i", 2))
+  assert.equal("-2", sprintf("%+i", -2))
+  assert.equal("2.2", sprintf("%f", 2.2))
+  assert.equal("-2.2", sprintf("%f", -2.2))
+  assert.equal("+2.2", sprintf("%+f", 2.2))
+  assert.equal("-2.2", sprintf("%+f", -2.2))
+  assert.equal("-2.3", sprintf("%+.1f", -2.34))
+  assert.equal("-0.0", sprintf("%+.1f", -0.01))
+  assert.equal("3.14159", sprintf("%.6g", pi))
+  assert.equal("3.14", sprintf("%.3g", pi))
+  assert.equal("3", sprintf("%.1g", pi))
+  assert.equal("-000000123", sprintf("%+010d", -123))
+  assert.equal("______-123", sprintf("%+'_10d", -123))
+  assert.equal("-234.34 123.2", sprintf("%f %f", -234.34, 123.2))
+
+  // padding
+  assert.equal("-0002", sprintf("%05d", -2))
+  assert.equal("-0002", sprintf("%05i", -2))
+  assert.equal("    <", sprintf("%5s", "<"))
+  assert.equal("0000<", sprintf("%05s", "<"))
+  assert.equal("____<", sprintf("%'_5s", "<"))
+  assert.equal(">    ", sprintf("%-5s", ">"))
+  assert.equal(">0000", sprintf("%0-5s", ">"))
+  assert.equal(">____", sprintf("%'_-5s", ">"))
+  assert.equal("xxxxxx", sprintf("%5s", "xxxxxx"))
+  assert.equal("1234", sprintf("%02u", 1234))
+  assert.equal(" -10.235", sprintf("%8.3f", -10.23456))
+  assert.equal("-12.34 xxx", sprintf("%f %s", -12.34, "xxx"))
+  assert.equal('{\n  "foo": "bar"\n}', sprintf("%2j", {foo: "bar"}))
+  assert.equal('[\n  "foo",\n  "bar"\n]', sprintf("%2j", ["foo", "bar"]))
+
+  // precision
+  assert.equal("2.3", sprintf("%.1f", 2.345))
+  assert.equal("xxxxx", sprintf("%5.5s", "xxxxxx"))
+  assert.equal("    x", sprintf("%5.1s", "xxxxxx"))
+
+  // should return formated strings for callbacks
+  assert.equal("foobar", sprintf("%s", function() { return "foobar" }))
+  assert.equal(Date.now(), sprintf("%s", Date.now)) // should pass...
 });
 


### PR DESCRIPTION
This PR replaces `sprintf` with the latest version from the [same source](https://github.com/alexei/sprintf.js). Previous version was 0.7-beta1, new is 1.0.3 Sprintf tests have been replaced with the source ones, together with copyright information included on top of a file.
