### PR TITLE
Clean old Romanian diacritics

### DIFF
--- a/cleanDiacritics.js
+++ b/cleanDiacritics.js
@@ -1,8 +1,8 @@
 
 var makeString = require('./helper/makeString');
 
-var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž",
-    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz";
+var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșşšŝťțţŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssstttuuuuuunyyczzz";
 
 from += from.toUpperCase();
 to += to.toUpperCase();

--- a/tests/cleanDiacritics.js
+++ b/tests/cleanDiacritics.js
@@ -2,8 +2,8 @@
 var equal = require('assert').equal;
 var cleanDiacritics = require('../cleanDiacritics');
 
-var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșšŝťțŭùúüűûñÿýçżźž",
-    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssttuuuuuunyyczzz";
+var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșşšŝťțţŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssstttuuuuuunyyczzz";
 
 test('#cleanDiacritics', function() {
 


### PR DESCRIPTION
Added two characters, the 's' and 't' with comma underneath them to be replaced with their equivalent characters. Those two characters have been replaced in the Romanian language with the ones that have cedillas underneath, not commas. Still, some people use the old characters, so this pull request cleans those old Romanian diacritics as well.