### PR TITLE
Update node versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "0.11"
-  - "iojs"
+  - "0.12"
+  - "stable"


### PR DESCRIPTION
`0.11` was really never a thing, so `0.12` if you want to test the old guard.  And then `stable` should be a good replacement for iojs