### PR TITLE
clean czech diacritics

### DIFF
--- a/cleanDiacritics.js
+++ b/cleanDiacritics.js
@@ -1,8 +1,8 @@
 
 var makeString = require('./helper/makeString');
 
-var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșşšŝťțţŭùúüűûñÿýçżźž",
-    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssstttuuuuuunyyczzz";
+var from  = "ąàáäâãåæăćčĉďęèéëêěĝĥìíïîĵłľńňòóöőôõðøřśșşšŝťțţŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaacccdeeeeeeghiiiijllnnoooooooorssssstttuuuuuunyyczzz";
 
 from += from.toUpperCase();
 to += to.toUpperCase();

--- a/tests/cleanDiacritics.js
+++ b/tests/cleanDiacritics.js
@@ -2,8 +2,8 @@
 var equal = require('assert').equal;
 var cleanDiacritics = require('../cleanDiacritics');
 
-var from  = "ąàáäâãåæăćčĉęèéëêĝĥìíïîĵłľńňòóöőôõðøśșşšŝťțţŭùúüűûñÿýçżźž",
-    to    = "aaaaaaaaaccceeeeeghiiiijllnnoooooooossssstttuuuuuunyyczzz";
+var from  = "ąàáäâãåæăćčĉďęèéëêěĝĥìíïîĵłľńňòóöőôõðøřśșşšŝťțţŭùúüűûñÿýçżźž",
+    to    = "aaaaaaaaacccdeeeeeeghiiiijllnnoooooooorssssstttuuuuuunyyczzz";
 
 test('#cleanDiacritics', function() {
 
@@ -20,5 +20,7 @@ test('#cleanDiacritics', function() {
 
   equal(cleanDiacritics('ß'), 'ss');
   equal(cleanDiacritics('Schuß'), 'Schuss');
+  
+  equal(cleanDiacritics('vstřícná odpověď'), 'vstricna odpoved');
 });
 


### PR DESCRIPTION
Added three missing characters from czech language to be replaced by cleanDiacritics: ď, ě, ř