### PR TITLE
#490 - addPossession

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -115,6 +115,21 @@ filter(S.startsWith('.'), [
 
 ### Individual functions
 
+
+#### addPossession(string) => string
+
+Adds possession to string where relevant
+
+```javascript
+addPossession("Apple");
+// => "Apple's"
+```
+
+```javascript
+addPossession("Apple's");
+// => "Apple's"
+```
+
 #### numberFormat(number, [ decimals=0, decimalSeparator='.', orderSeparator=',']) => string
 
 Formats the numbers.

--- a/addPossession.js
+++ b/addPossession.js
@@ -1,0 +1,18 @@
+var endsWith = require('./endsWith');
+var makeString = require('./helper/makeString');
+
+module.exports = function addPossession(str) {
+  str = makeString(str);
+
+  if (endsWith(str, '\'')) {
+    return str;
+  }
+  if (endsWith(str, '\'s') || endsWith(str, '`s') || endsWith(str, '´s')) {
+    return str;
+  }
+  if (endsWith(str, 's')) {
+    return str + '\'';
+  }
+
+  return str + '\'s';
+};

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function s(value) {
 
 s.VERSION = '3.3.4';
 
+s.addPossession    = require('./addPossession');
 s.isBlank          = require('./isBlank');
 s.stripTags        = require('./stripTags');
 s.capitalize       = require('./capitalize');

--- a/tests/addPossession.js
+++ b/tests/addPossession.js
@@ -4,9 +4,9 @@ var addPossession = require('../addPossession');
 
 test('#addPossession', function() {
   equal(addPossession('Apples\''), 'Apples\'');
-  equal(addPossession('Apples\'s'), 'Apples\'s');
-  equal(addPossession('Apples\`s'), 'Apples\`s');
-  equal(addPossession('Apples\´s'), 'Apples\´s');
+  equal(addPossession('Apple\'s'), 'Apple\'s');
+  equal(addPossession('Apple\`s'), 'Apple\`s');
+  equal(addPossession('Apple\´s'), 'Apple\´s');
   equal(addPossession('Apples'), 'Apples\'');
   equal(addPossession('Apple'), 'Apple\'s');
 });

--- a/tests/addPossession.js
+++ b/tests/addPossession.js
@@ -1,0 +1,12 @@
+var equal = require('assert').equal;
+var addPossession = require('../addPossession');
+
+
+test('#addPossession', function() {
+  equal(addPossession('Apples\''), 'Apples\'');
+  equal(addPossession('Apples\'s'), 'Apples\'s');
+  equal(addPossession('Apples\`s'), 'Apples\`s');
+  equal(addPossession('Apples\´s'), 'Apples\´s');
+  equal(addPossession('Apples'), 'Apples\'');
+  equal(addPossession('Apple'), 'Apple\'s');
+});


### PR DESCRIPTION
## Changes

Implements a new possession helper outlined in issue #490. I've updated the function to be called `addPossession` rather than `addApostrophe` to be clearer.

Obviously, there are a number of [rules](https://www.scribendi.com/advice/using_apostrophes.en.html) around how to use an apostrophe, this functionality doesn't take this into account but gives a quick solution to add possession.

Any thoughts or comments are greatly appreciated.
